### PR TITLE
Fix cmakeLists err: lower to uppercase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,5 +91,5 @@ if(GPMP2_BUILD_PYTHON_TOOLBOX)
 endif()
 
 # Install config and export files
-GtsamMakeConfigFile(gpmp2)
+GtsamMakeConfigFile(GPMP2)
 export(TARGETS ${GPMP2_EXPORTED_TARGETS} FILE gpmp2-exports.cmake)


### PR DESCRIPTION
This PR change the Projectname passed to GtsamModule.cmake  to uppercase, since it is GPMP2_VERSION defined, not gpmp2_VERSION. 
Thanks(: